### PR TITLE
Fixed 'Bookmark this ticket' button showing even if the ticket is already ...

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,7 +78,7 @@
       if ( ticketID == null ) { return false; }
 
       var alreadyBookmarked = _.any(this.bookmarks, function(b) {
-        return b.ticket.nice_id === ticketID;
+        return b.ticket.id === ticketID;
       });
 
       return !alreadyBookmarked;


### PR DESCRIPTION
'Bookmark this ticket' button is showing even if the ticket is already bookmarked. This actually cause by the use of ticket.nice_id, where using the ticket.id is sufficient. I do not find any nice_id documentation in API V2.