### PR TITLE
removed # from link causing agent interface to try loading the achnor…

### DIFF
--- a/templates/list.hdbs
+++ b/templates/list.hdbs
@@ -2,7 +2,7 @@
   <ul>
     {{#bookmarks}}
       <li data-bookmark-id="{{id}}">
-        <a href="#/bookmarks/{{id}}/destroy" class="destroy" rel="nofollow" title="{{t "delete_bookmark"}}">
+        <a href="/bookmarks/{{id}}/destroy" class="destroy" rel="nofollow" title="{{t "delete_bookmark"}}">
           <i class='icon-remove-circle'></i>
         </a>
         <a href="#/tickets/{{ticket.id}}">{{ticket.subject}}</a>


### PR DESCRIPTION
The template for bookmark list uses an anchor and prevents default behavior but the agent inteface still picks up links with a # in them. This PR simply removes the preceding hashtag and makes everything okay again. 

@Nebopolis or @ckumar1 mind taking a quick look?
